### PR TITLE
Remove erroneous leftover method call from Schema::getColumnListing()

### DIFF
--- a/src/Database/Schema/Builder.php
+++ b/src/Database/Schema/Builder.php
@@ -63,9 +63,6 @@ class Builder extends \Illuminate\Database\Schema\Builder
             $table,
         ]);
 
-        $res = $this->connection->getPostProcessor()
-            ->processColumnListing($results);
-
         return array_values(array_map(function($r) {
             return $r->column_name;
         }, $results));


### PR DESCRIPTION
Remove erroneous leftover method call from Schema::getColumnListing()