### PR TITLE
Use user-provided index name in migrations if present

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,10 @@
     {
         "name": "Levi Vanheel",
         "role": "Developer"
+    },
+    {
+        "name": "Neal Van Meerbeek",
+        "role": "Developer"
     }
     ],
     "require": {

--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -107,12 +107,9 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
         switch ($type) {
             case 'index':
                 $indexSystem = false;
-
-                if (!is_null($index)) {
-                    //$indexSystem = $index;
+                if (is_null($index)) {
+                    $index = $this->createIndexName($type, $columns);
                 }
-
-                $index = $this->createIndexName($type, $columns);
 
                 return $this->addCommand($type, compact('index', 'indexSystem', 'columns'));
             default:


### PR DESCRIPTION
See #51 