### PR TITLE
Laravel v12.21 compatibility

### DIFF
--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -61,11 +61,25 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
      * @param  \Illuminate\Database\Connection  $connection
      * @return void
      */
-    protected function addReplyListEntryCommands(Connection $connection)
+    protected function addReplyListEntryCommands(Connection $connection): void
     {
-        if ($this->commandsNamed(['dropColumn', 'renameColumn'])->count() > 0) {
-            array_unshift($this->commands, $this->createCommand('addReplyListEntry'), $this->createCommand('changeJob'));
-            array_push($this->commands, $this->createCommand('removeReplyListEntry'));
+        $hasDropOrRename = false;
+
+        foreach ($this->getCommands() as $command) {
+            if (in_array($command->get('name'), ['dropColumn', 'renameColumn'], true)) {
+                $hasDropOrRename = true;
+                break;
+            }
+        }
+
+        if ($hasDropOrRename) {
+            array_unshift(
+                $this->commands,
+                $this->createCommand('addReplyListEntry'),
+                $this->createCommand('changeJob')
+            );
+
+            $this->commands[] = $this->createCommand('removeReplyListEntry');
         }
     }
 
@@ -94,13 +108,15 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
     /**
      * Add a new index command to the blueprint.
      *
-     * @param  string $type
-     * @param  string|array $columns
-     * @param  string $index
      *
+     * @param string $type
+     * @param array|string $columns
+     * @param string $index
+     * @param null $algorithm
+     * @param null $operatorClass
      * @return \Illuminate\Support\Fluent
      */
-    protected function indexCommand($type, $columns, $index, $algorithm = null)
+    protected function indexCommand($type, $columns, $index, $algorithm = null, $operatorClass = null)
     {
         $columns = (array) $columns;
 

--- a/src/Database/Schema/Builder.php
+++ b/src/Database/Schema/Builder.php
@@ -92,17 +92,19 @@ class Builder extends \Illuminate\Database\Schema\Builder
      * Create a new command set with a Closure.
      *
      * @param string $table
-     * @param \Closure $callback
+     * @param Closure|null $callback
      *
-     * @return \Easi\DB2\Database\Schema\Blueprint
+     * @return Blueprint
      */
-    protected function createBlueprint($table, Closure $callback = null)
+    protected function createBlueprint($table, ?Closure $callback = null)
     {
+        $connection = $this->connection;
+
         if (isset($this->resolver)) {
             return call_user_func($this->resolver, $table, $callback);
         }
 
-        return new \Easi\DB2\Database\Schema\Blueprint($table, $callback);
+        return new \Easi\DB2\Database\Schema\Blueprint($connection, $table, $callback);
     }
 
     /**

--- a/src/Database/Schema/Grammars/DB2Grammar.php
+++ b/src/Database/Schema/Grammars/DB2Grammar.php
@@ -75,10 +75,8 @@ class DB2Grammar extends Grammar
     /**
      * Compile a create table command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
-     * @param  \Illuminate\Support\Fluent            $command
-     * @param  \Illuminate\Database\Connection       $connection
-     *
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileCreate(Blueprint $blueprint, Fluent $command)
@@ -98,13 +96,11 @@ class DB2Grammar extends Grammar
     /**
      * Compile a label command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
-     * @param  \Illuminate\Support\Fluent            $command
-     * @param  \Illuminate\Database\Connection       $connection
-     *
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
-    public function compileLabel(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileLabel(Blueprint $blueprint, Fluent $command)
     {
         return 'label on table ' . $this->wrapTable($blueprint) . ' is \'' . $command->label . '\'';
     }
@@ -902,13 +898,11 @@ class DB2Grammar extends Grammar
     /**
      * Compile an addReplyListEntry command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
-     * @param  \Illuminate\Support\Fluent            $command
-     * @param  \Illuminate\Database\Connection  $connection
-     *
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
-    public function compileAddReplyListEntry(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileAddReplyListEntry(Blueprint $blueprint, Fluent $command)
     {
         $sequenceNumberQuery = <<<EOT
             with reply_list_info(sequence_number) as (
@@ -927,7 +921,7 @@ class DB2Grammar extends Grammar
             )
 EOT;
 
-        $blueprint->setReplyListSequenceNumber($sequenceNumber = $connection->selectOne($sequenceNumberQuery)->sequence_number);
+        $blueprint->setReplyListSequenceNumber($sequenceNumber = $this->connection->selectOne($sequenceNumberQuery)->sequence_number);
         $command->command = "ADDRPYLE SEQNBR($sequenceNumber) MSGID(CPA32B2) RPY(''I'')";
 
         return $this->compileExecuteCommand($blueprint, $command);


### PR DESCRIPTION
Closes #54 

1. Update `Blueprint` constructor signature, as documented in the [Laravel V12 Upgrade Guide](https://laravel.com/docs/12.x/upgrade?utm_source=chatgpt.com#updated-blueprint-constructor-signature)
2. Replace the deprecated `Blueprint->commandsNamed` with `Blueprint->getCommands()` and a `foreach-loop`.
3. In `DB2Grammar`, remove the `Connection` parameter from any methods requiring it. Instead, use the field value `$this->connection`.
4. Add the newly added `$operatorClass` parameter to `Blueprint->indexCommand`, added in Laravel v12.21. See the related GitHub issue https://github.com/laravel/framework/pull/56324